### PR TITLE
Re-use buffers even if they are read only.

### DIFF
--- a/cmd/ebuf.go
+++ b/cmd/ebuf.go
@@ -99,7 +99,9 @@ func main() {
            (when-let ((p (get-buffer-process buffer)))
              (when (process-live-p p)
                (error "a process is still active for '%s'" {{str .Name}})))
-           (with-current-buffer buffer (delete-region (point-min) (point-max)))
+           (with-current-buffer buffer
+             (setq buffer-read-only nil)
+             (delete-region (point-min) (point-max)))
            (setq default-directory pwd)
            (let ((process (start-process {{str .Name}} buffer "cat" {{str .Fifo}})))
              (set-process-filter process


### PR DESCRIPTION
If I make the mode `view-mode` when using `ebuf` it will fail to re-use the
buffer because the buffer is read-only when the buffer is cleared.

To fix this, set `buffer-read-only` to `nil`.

Before:
```
$ <command> | ebuf -u -m view '*pager*'
*pager*
$ <command> | ebuf -u -m view '*pager*'
*ERROR*: Buffer is read-only: #<buffer *pager*>
```

Now:
```
$ <command> | ebuf -u -m view '*pager*'
*pager*
$ <command> | ebuf -u -m view '*pager*'
*pager*
```