### PR TITLE
Revert "Update module name to match github"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/szermatt/emacsclient-commands
+module github.com/szermatt/emacsclient
 
 go 1.13
 


### PR DESCRIPTION
Reverts szermatt/emacsclient-commands#4

I merged too quickly; Changing just go.mod doesn't work, as the package name used in the must be consistent with go.mod. Also, emacsclient-commands isn't a valid package name. I'm not sure what the right solution is.